### PR TITLE
Add client tests and fix listen bug

### DIFF
--- a/packages/knit/src/client.test.ts
+++ b/packages/knit/src/client.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "@jest/globals";
+import { createClientWithTransport } from "./client.js";
+import { createRouterTransport } from "@bufbuild/connect";
+import type { AllService } from "@bufbuild/knit-test-spec/spec/all_knit.js";
+import { All } from "@bufbuild/knit-test-spec/spec/all_pb.js";
+import { KnitService } from "@buf/bufbuild_knit.bufbuild_connect-es/buf/knit/gateway/v1alpha1/knit_connect.js";
+import { type PartialMessage, Value } from "@bufbuild/protobuf";
+import {
+  FetchRequest,
+  FetchResponse,
+  Schema,
+  Schema_Field_Type_ScalarType,
+} from "@buf/bufbuild_knit.bufbuild_es/buf/knit/gateway/v1alpha1/knit_pb.js";
+import {
+  Scalar,
+  ScalarFields,
+} from "@bufbuild/knit-test-spec/spec/scalars_pb.js";
+import type { Query } from "./schema.js";
+
+describe("client", () => {
+  const schema: PartialMessage<Schema> = {
+    name: All.typeName,
+    fields: [
+      {
+        name: "scalars",
+        type: {
+          value: {
+            case: "message",
+            value: {
+              name: Scalar.typeName,
+              fields: [
+                {
+                  name: "fields",
+                  type: {
+                    value: {
+                      case: "message",
+                      value: {
+                        name: ScalarFields.typeName,
+                        fields: [
+                          {
+                            name: "str",
+                            type: {
+                              value: {
+                                case: "scalar",
+                                value: Schema_Field_Type_ScalarType.STRING,
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  };
+  const request = {
+    scalars: { fields: { str: "request" } },
+  };
+  const response = {
+    scalars: { fields: { str: "response" } },
+  };
+  const unary = ({ requests }: FetchRequest): PartialMessage<FetchResponse> => {
+    expect(requests).toHaveLength(1);
+    expect(requests[0].body?.toJson()).toEqual(request);
+    return {
+      responses: [
+        {
+          body: Value.fromJson(response),
+          schema: schema,
+          method: requests[0].method,
+        },
+      ],
+    };
+  };
+  const client = createClientWithTransport<AllService>(
+    createRouterTransport(({ service }) => {
+      service(KnitService, {
+        fetch: unary,
+        do: unary,
+        async *listen({ request: actualRequest }) {
+          expect(actualRequest?.body?.toJson()).toEqual(request);
+          for (let i = 0; i < 5; i++) {
+            yield {
+              response: {
+                body: Value.fromJson(response),
+                schema: schema,
+                method: actualRequest?.method,
+              },
+            };
+          }
+        },
+      });
+    })
+  );
+  const allQuery = {
+    scalars: {
+      fields: {
+        str: {},
+      },
+    },
+  } satisfies Query<All>;
+  test("fetch", async () => {
+    const fetchResponse = await client.fetch({
+      "spec.AllService": {
+        getAll: {
+          $: request,
+          ...allQuery,
+        },
+      },
+    });
+    expect(fetchResponse["spec.AllService"].getAll).toEqual(response);
+  });
+  test("do", async () => {
+    const fetchResponse = await client.do({
+      "spec.AllService": {
+        createAll: {
+          $: request,
+          ...allQuery,
+        },
+      },
+    });
+    expect(fetchResponse["spec.AllService"].createAll).toEqual(response);
+  });
+  test("listen", async () => {
+    const listenResponse = client.listen({
+      "spec.AllService": {
+        streamAll: {
+          $: request,
+          ...allQuery,
+        },
+      },
+    });
+    let count = 0;
+    for await (const next of listenResponse) {
+      expect(next["spec.AllService"].streamAll).toEqual(response);
+      count++;
+    }
+    expect(count).toBe(5);
+  });
+});


### PR DESCRIPTION
Due to the function signature the return value was being wrapped in `AsyncGenerator` similar to a `Promise` with `async`. This PR removes the generator signature. It also adds tests to ensure it works as expected, previously we relied on TypeScript but that didn't catch this. All the actual logic already has tests.