### PR TITLE
Add relations to computed schema

### DIFF
--- a/packages/knit-gateway/src/schema.test.ts
+++ b/packages/knit-gateway/src/schema.test.ts
@@ -47,7 +47,7 @@ import {
   UInt64Value,
   Value,
 } from "@bufbuild/protobuf";
-import { Keys, Map } from "@bufbuild/knit-test-spec/spec/map_pb.js";
+import { Keys, Map as ProtoMap } from "@bufbuild/knit-test-spec/spec/map_pb.js";
 import { Message } from "@bufbuild/knit-test-spec/spec/messages_pb.js";
 
 describe("valid mask", () => {
@@ -206,7 +206,7 @@ describe("valid mask", () => {
     },
     {
       name: "Maps",
-      message: Map,
+      message: ProtoMap,
       mask: [
         {
           name: "message",
@@ -214,7 +214,7 @@ describe("valid mask", () => {
         },
       ],
       schema: {
-        name: Map.typeName,
+        name: ProtoMap.typeName,
         fields: [
           {
             name: "message",
@@ -223,7 +223,7 @@ describe("valid mask", () => {
                 case: "map",
                 value: {
                   key: Schema_Field_Type_ScalarType.STRING,
-                  value: messageElement(Map, [
+                  value: messageElement(ProtoMap, [
                     {
                       name: "enum",
                       type: {
@@ -327,7 +327,8 @@ describe("valid mask", () => {
           computeSchema(
             testCase.message,
             testCase.mask.map((m) => new MaskField(m)),
-            ""
+            "",
+            new Map()
           )
         )
       ).toEqual(new Schema(testCase.schema));
@@ -358,7 +359,8 @@ describe("invalid mask", () => {
         computeSchema(
           testCase.message,
           testCase.mask.map((m) => new MaskField(m)),
-          ""
+          "",
+          new Map()
         )
       ).toThrow();
     });

--- a/packages/knit-gateway/src/service.ts
+++ b/packages/knit-gateway/src/service.ts
@@ -152,7 +152,7 @@ export function createKnitService<T extends readonly ServiceType[]>({
 }
 
 async function handleUnary(
-  { entryPoints }: Gateway,
+  { entryPoints, relations }: Gateway,
   requests: Request[],
   requestHeader: Headers,
   forFetch?: boolean
@@ -182,10 +182,13 @@ async function handleUnary(
         Code.InvalidArgument
       );
     }
-    const schema = computeSchema(
-      entryPoint.method.O,
-      request.mask,
-      request.method
+    const schema = new Schema(
+      computeSchema(
+        entryPoint.method.O,
+        request.mask,
+        request.method,
+        relations
+      )
     );
     responses = [
       ...responses,
@@ -205,7 +208,7 @@ async function handleUnary(
 }
 
 async function handleStream(
-  { entryPoints }: Gateway,
+  { entryPoints, relations }: Gateway,
   request: Request | undefined,
   requestHeader: Headers
 ): Promise<AsyncIterable<PartialMessage<Response>>> {
@@ -222,10 +225,8 @@ async function handleStream(
       Code.InvalidArgument
     );
   }
-  const schema = computeSchema(
-    entryPoint.method.O,
-    request.mask,
-    request.method
+  const schema = new Schema(
+    computeSchema(entryPoint.method.O, request.mask, request.method, relations)
   );
   const { message } = await entryPoint.transport.stream(
     entryPoint.service,


### PR DESCRIPTION
This is first of a series of PRs to add relation support to the gateway package. This adds a `Relation` type and updates `computeSchema` to include relation information.