### PR TITLE
Fix types for `bytes` fields

### DIFF
--- a/packages/knit/src/schema.test.ts
+++ b/packages/knit/src/schema.test.ts
@@ -46,6 +46,7 @@ import type { Value, Struct } from "./wkt/struct.js";
 import type { Any } from "./wkt/any.js";
 import { FieldMask } from "./wkt/field_mask.js";
 import type { KnitError } from "./error.js";
+import type { ScalarFields } from "@bufbuild/knit-test-spec/spec/scalars_knit.js";
 
 describe("wkt", () => {
   const [
@@ -364,6 +365,70 @@ describe("wkt", () => {
         value: [{}],
       } satisfies Parameter<Wkt["repeated"]>;
     });
+  });
+});
+
+describe("scalars", () => {
+  test("query", () => {
+    const query = {
+      str: {},
+      bl: {},
+      i32: {},
+      i64: {},
+      u32: {},
+      u64: {},
+      s32: {},
+      s64: {},
+      f32: {},
+      f64: {},
+      sf32: {},
+      sf64: {},
+      by: {},
+      db: {},
+      fl: {},
+    } satisfies Query<ScalarFields>;
+    type Actual = Mask<typeof query, ScalarFields>;
+    type Expected = {
+      str: string;
+      bl: boolean;
+      i32: number;
+      i64: bigint;
+      u32: number;
+      u64: bigint;
+      s32: number;
+      s64: bigint;
+      f32: number;
+      f64: bigint;
+      sf32: number;
+      sf64: bigint;
+      by: Uint8Array;
+      db: number;
+      fl: number;
+    };
+    type Diff = DeepDiff<Actual, Expected>;
+    expectType<Equal<Diff, never>>(true);
+  });
+  test("params", () => {
+    type Actual = Parameter<ScalarFields>;
+    type Expected = {
+      str?: string;
+      bl?: boolean;
+      i32?: number;
+      i64?: bigint;
+      u32?: number;
+      u64?: bigint;
+      s32?: number;
+      s64?: bigint;
+      f32?: number;
+      f64?: bigint;
+      sf32?: number;
+      sf64?: bigint;
+      by?: Uint8Array;
+      db?: number;
+      fl?: number;
+    };
+    type Diff = DeepDiff<Actual, Expected>;
+    expectType<Equal<Diff, never>>(true);
   });
 });
 

--- a/packages/knit/src/schema.ts
+++ b/packages/knit/src/schema.ts
@@ -85,6 +85,8 @@ export type Query<T> =
   ? Query<V>
   : T extends keyof WktTypeTable
   ? ScalarQuery
+  : T extends Uint8Array
+  ? ScalarQuery
   : T extends RelationMarker<infer P, infer V>
   ? ( 
       P extends undefined
@@ -128,7 +130,9 @@ export type Parameter<T> =
   ? Alias<K, Parameter<V>>
   : T extends keyof WktTypeTable
   ? WktTypeTable[T]
-  : T extends AnyRecord
+  : T extends Uint8Array
+  ? Uint8Array
+  : T extends AnyRecord  
   ? {
     // Exclude the Knit relation fields
       [ K in keyof T as T[K] extends RelationMarker<unknown, unknown> | undefined ? never: K]?: Parameter<T[K]>;
@@ -175,6 +179,8 @@ export type Mask<Q, R, ES extends ErrorStrategy = ErrorStrategyThrow> =
   ? Mask<Q, V, ES>
   : R extends keyof WktTypeTable
   ? WktTypeTable[R]
+  : R extends Uint8Array
+  ? R
   : R extends RelationMarker<unknown, infer V>
   ? Mask<Q, V, ES> | ErrorMask<Q, ES>
   : R extends AnyRecord


### PR DESCRIPTION
`bytes` are represented using `Uint8Array` which is an object and hence it was being treated as one. This checks for it explicitly.