### PR TITLE
Add end-to-end tests to gateway

### DIFF
--- a/packages/knit-gateway/src/schema.test.ts
+++ b/packages/knit-gateway/src/schema.test.ts
@@ -328,6 +328,7 @@ describe("valid mask", () => {
             testCase.message,
             testCase.mask.map((m) => new MaskField(m)),
             "",
+            new Map(),
             new Map()
           )
         )
@@ -360,6 +361,7 @@ describe("invalid mask", () => {
           testCase.message,
           testCase.mask.map((m) => new MaskField(m)),
           "",
+          new Map(),
           new Map()
         )
       ).toThrow();

--- a/packages/knit-gateway/src/schema.ts
+++ b/packages/knit-gateway/src/schema.ts
@@ -91,9 +91,20 @@ function applyMask(
           Code.InvalidArgument
         );
       }
-      field.params = schemaField.relation.params.fromJson(
-        maskField.params.toJson()
-      );
+      try {
+        field.params = schemaField.relation.params.fromJson(
+          maskField.params.toJson()
+        );
+      } catch (err) {
+        // Must be invalid json
+        throw new ConnectError(
+          `Invalid params passed at ${fieldPath}`,
+          Code.InvalidArgument,
+          undefined,
+          undefined,
+          err
+        );
+      }
     }
     fields.push(field);
     localNameTable.set(maskField.name, field);

--- a/packages/knit-gateway/src/schema.ts
+++ b/packages/knit-gateway/src/schema.ts
@@ -57,9 +57,14 @@ export function computeSchema(
   message: MessageType,
   mask: MaskField[],
   path: string,
-  relations: RelationsMap
+  relations: RelationsMap,
+  schemaCache: Map<string, PlainSchema>
 ): PlainSchema {
-  return applyMask(getMessageSchema(message, relations), mask, path);
+  return applyMask(
+    getMessageSchema(message, relations, schemaCache),
+    mask,
+    path
+  );
 }
 
 function applyMask(
@@ -169,13 +174,12 @@ function applyMaskToType(
   return { value: type };
 }
 
-const messageToSchemaTable = new Map<string, PlainSchema>();
-
 function getMessageSchema(
   message: MessageType,
-  relations: RelationsMap
+  relations: RelationsMap,
+  schemaCache: Map<string, PlainSchema>
 ): PlainSchema {
-  let schema = messageToSchemaTable.get(message.typeName);
+  let schema = schemaCache.get(message.typeName);
   if (schema !== undefined) {
     return schema;
   }
@@ -186,8 +190,8 @@ function getMessageSchema(
   };
   // To handle recursive types, we need to add the schema to the table before
   // computing the fields.
-  messageToSchemaTable.set(message.typeName, schema);
-  const fields = computeMessageFields(message, relations);
+  schemaCache.set(message.typeName, schema);
+  const fields = computeMessageFields(message, relations, schemaCache);
   schema.fields = fields;
   schema.localNameTable = new Map(fields.map((f) => [f.name, f]));
   return schema;
@@ -195,7 +199,8 @@ function getMessageSchema(
 
 function computeMessageFields(
   message: MessageType,
-  relations: RelationsMap
+  relations: RelationsMap,
+  schemaCache: Map<string, PlainSchema>
 ): PlainSchemaField[] {
   if (wktSet.has(message.typeName)) {
     return [];
@@ -206,7 +211,7 @@ function computeMessageFields(
       name: protoField.localName,
       jsonName:
         protoField.jsonName !== protoField.localName ? protoField.jsonName : "",
-      type: computeFieldType(protoField, relations),
+      type: computeFieldType(protoField, relations, schemaCache),
       path: "",
       onError: { case: undefined },
     });
@@ -215,7 +220,7 @@ function computeMessageFields(
     fields.push({
       name: relation.field.localName,
       jsonName: "",
-      type: computeFieldType(relation.field, relations),
+      type: computeFieldType(relation.field, relations, schemaCache),
       path: "",
       relation: relation,
       onError: { case: undefined },
@@ -226,13 +231,14 @@ function computeMessageFields(
 
 function computeFieldType(
   protoField: FieldInfo,
-  relations: RelationsMap
+  relations: RelationsMap,
+  schemaCache: Map<string, PlainSchema>
 ): PlainSchemaFieldType {
   if (protoField.kind === "map") {
-    return computeMapType(protoField, relations);
+    return computeMapType(protoField, relations, schemaCache);
   }
   if (protoField.repeated) {
-    return computeRepeatedType(protoField, relations);
+    return computeRepeatedType(protoField, relations, schemaCache);
   }
   switch (protoField.kind) {
     case "enum":
@@ -244,7 +250,7 @@ function computeFieldType(
       return {
         value: {
           case: "message",
-          value: getMessageSchema(protoField.T, relations),
+          value: getMessageSchema(protoField.T, relations, schemaCache),
         },
       };
   }
@@ -254,7 +260,8 @@ function computeRepeatedType(
   protoField: FieldInfo & { readonly repeated: boolean } & {
     kind: "scalar" | "enum" | "message";
   },
-  relations: RelationsMap
+  relations: RelationsMap,
+  schemaCache: Map<string, PlainSchema>
 ): PlainSchemaFieldType {
   return {
     value: {
@@ -264,7 +271,7 @@ function computeRepeatedType(
           protoField.kind === "message"
             ? {
                 case: "message",
-                value: getMessageSchema(protoField.T, relations),
+                value: getMessageSchema(protoField.T, relations, schemaCache),
               }
             : {
                 case: "scalar",
@@ -277,7 +284,8 @@ function computeRepeatedType(
 
 function computeMapType(
   protoField: FieldInfo & { kind: "map" },
-  relations: RelationsMap
+  relations: RelationsMap,
+  schemaCache: Map<string, PlainSchema>
 ): PlainSchemaFieldType {
   return {
     value: {
@@ -288,7 +296,7 @@ function computeMapType(
           protoField.V.kind === "message"
             ? {
                 case: "message",
-                value: getMessageSchema(protoField.V.T, relations),
+                value: getMessageSchema(protoField.V.T, relations, schemaCache),
               }
             : {
                 case: "scalar",

--- a/packages/knit-gateway/src/service.ts
+++ b/packages/knit-gateway/src/service.ts
@@ -268,8 +268,21 @@ async function handleStream(
   return pipe(
     message,
     async function* (messageIterable) {
+      let schemaSent = false;
       for await (const message of messageIterable) {
-        yield await makeResponse(request, schema, message, false, typeRegistry);
+        const response = await makeResponse(
+          request,
+          schema,
+          message,
+          false,
+          typeRegistry
+        );
+        if (schemaSent) {
+          delete response.schema;
+        } else {
+          schemaSent = true;
+        }
+        yield response;
       }
     },
     {

--- a/packages/knit-gateway/src/service.ts
+++ b/packages/knit-gateway/src/service.ts
@@ -113,6 +113,7 @@ export function createKnitService({
 }: CreateKnitServiceOptions): ServiceImpl<typeof KnitService> {
   const gateway = createGateway({ transport, timeoutMs });
   configure(gateway);
+  const schemaCache = new Map<string, PlainMessage<Schema>>();
   return {
     async do({ requests }, { requestHeader }) {
       return new DoResponse({
@@ -121,7 +122,8 @@ export function createKnitService({
           requests,
           requestHeader,
           false,
-          typeRegistry
+          typeRegistry,
+          schemaCache
         ),
       });
     },
@@ -132,7 +134,8 @@ export function createKnitService({
           requests,
           requestHeader,
           true,
-          typeRegistry
+          typeRegistry,
+          schemaCache
         ),
       });
     },
@@ -141,7 +144,8 @@ export function createKnitService({
         gateway,
         request,
         requestHeader,
-        typeRegistry
+        typeRegistry,
+        schemaCache
       );
       for await (const response of iterable) {
         yield new ListenResponse({ response });
@@ -155,7 +159,8 @@ async function handleUnary(
   requests: Request[],
   requestHeader: Headers,
   forFetch: boolean,
-  typeRegistry: IMessageTypeRegistry | undefined
+  typeRegistry: IMessageTypeRegistry | undefined,
+  schemaCache: Map<string, PlainMessage<Schema>>
 ): Promise<PartialMessage<Response>[]> {
   // TODO: Create a typeRegistry for the schema and use that if
   // typeRegistry is not provided. It is not sound, but it should be good enough.
@@ -190,7 +195,8 @@ async function handleUnary(
       entryPoint.method.O,
       request.mask,
       request.method,
-      relations
+      relations,
+      schemaCache
     );
     results.push(
       (async () => {
@@ -234,7 +240,8 @@ async function handleStream(
   { entryPoints, relations }: Gateway,
   request: Request | undefined,
   requestHeader: Headers,
-  typeRegistry?: IMessageTypeRegistry
+  typeRegistry: IMessageTypeRegistry | undefined,
+  schemaCache: Map<string, PlainMessage<Schema>>
 ): Promise<AsyncIterable<PartialMessage<Response>>> {
   if (request === undefined) {
     throw new ConnectError(`No request provided`, Code.InvalidArgument);
@@ -253,7 +260,8 @@ async function handleStream(
     entryPoint.method.O,
     request.mask,
     request.method,
-    relations
+    relations,
+    schemaCache
   );
   const { message } = await entryPoint.transport.stream(
     entryPoint.service,

--- a/packages/knit-gateway/src/stitch.ts
+++ b/packages/knit-gateway/src/stitch.ts
@@ -71,7 +71,7 @@ async function resolveBatch(
     const knitError = formatError(err, "", typeRegistry);
     for (const errorPatch of errorPatches) {
       if (errorPatch === undefined) {
-        throw knitError;
+        throw err;
       }
       errorPatch.target[errorPatch.name] = knitError;
     }


### PR DESCRIPTION
[//]: <> (Closes TCN-1776)


Add e2e tests. 

Caught and fixed some minor bugs:
- Return the correct error code of failed to parse params
- Return the original connect error in the case of throw
- Return schema only in the first response in `listen`

This also moves the schema cache to be request scoped. This comes up if different resolvers are being used for the same relation in different gateways, practically may not be a problem but better to not have a global cache. (I was intending to move this later but the tests required me to).

The diff is largely due to to snapshots. It may be better to look at `service.test.ts` changes side-by-side it is a complete rewrite.