### PR TITLE
Fix exports; Add `attw` to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: lint
-        run: pnpm run lint      
+        run: pnpm run lint
   test:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: lint
-        run: pnpm run lint
+        run: pnpm run lint      
   test:
     runs-on: ubuntu-20.04
     steps:
@@ -23,3 +23,5 @@ jobs:
         uses: ./.github/actions/setup
       - name: test
         run: pnpm run test
+      - name: attw
+        run: pnpm run attw

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean": "turbo run clean --no-daemon --cache-dir=.turbo",
     "build": "turbo run build --no-daemon --cache-dir=.turbo",
     "lint": "turbo run lint --no-daemon --cache-dir=.turbo",
+    "attw": "turbo run attw --no-daemon --cache-dir=.turbo",
     "test": "turbo run test --no-daemon --cache-dir=.turbo",
     "test:watch": "turbo run test:watch --no-daemon --cache-dir=.turbo",
     "buf:generate": "turbo run buf:generate --no-daemon --cache-dir=.turbo",
@@ -21,7 +22,8 @@
     "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "turbo": "^1.10.14",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "@arethetypeswrong/cli": "^0.11.0"
   },
   "engines": {
     "node": ">=18.16.0",

--- a/packages/knit/package.json
+++ b/packages/knit/package.json
@@ -15,7 +15,7 @@
     "attw": "attw --pack",
     "test": "NODE_OPTIONS=--experimental-vm-modules ../../node_modules/.bin/jest",
     "test:watch": "pnpm run build:esm+types --watch & pnpm run test --watchAll",
-    "build:esm": "tsup --format esm",
+    "build:esm": "tsup --format esm && mv ./dist/esm/index.d.mts ./dist/esm/index.d.ts && mv ./dist/esm/gateway/index.d.mts ./dist/esm/gateway/index.d.ts",
     "build:cjs": "tsup --format cjs",
     "build": "pnpm run build:esm && pnpm run build:cjs"
   },
@@ -23,7 +23,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/esm/index.d.mts",
+        "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       },
       "require": {
@@ -33,7 +33,7 @@
     },
     "./gateway": {
       "import": {
-        "types": "./dist/esm/gateway/index.d.mts",
+        "types": "./dist/esm/gateway/index.d.ts",
         "default": "./dist/esm/gateway/index.js"
       },
       "require": {

--- a/packages/knit/package.json
+++ b/packages/knit/package.json
@@ -9,35 +9,45 @@
     "directory": "packages/knit"
   },
   "sideEffects": false,
-  "type": "module",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./gateway": {
-      "import": "./dist/esm/gateway/index.js",
-      "require": "./dist/cjs/gateway/index.js"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "gateway": [
-        "./dist/esm/gateway/index.d.ts",
-        "./dist/cjs/gateway/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "clean": "rm -rf ./dist/* .turbo/*",
     "lint": "eslint .",
+    "attw": "attw --pack",
     "test": "NODE_OPTIONS=--experimental-vm-modules ../../node_modules/.bin/jest",
     "test:watch": "pnpm run build:esm+types --watch & pnpm run test --watchAll",
     "build:esm": "tsup --format esm",
     "build:cjs": "tsup --format cjs",
     "build": "pnpm run build:esm && pnpm run build:cjs"
+  },
+  "main": "./dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./gateway": {
+      "import": {
+        "types": "./dist/esm/gateway/index.d.mts",
+        "default": "./dist/esm/gateway/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/gateway/index.d.ts",
+        "default": "./dist/cjs/gateway/index.js"
+      }
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "gateway": [
+        "./dist/cjs/gateway/index.d.ts"
+      ]
+    }
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.3.1",

--- a/packages/knit/package.json
+++ b/packages/knit/package.json
@@ -9,14 +9,15 @@
     "directory": "packages/knit"
   },
   "sideEffects": false,
+  "type": "module",
   "scripts": {
     "clean": "rm -rf ./dist/* .turbo/*",
     "lint": "eslint .",
     "attw": "attw --pack",
     "test": "NODE_OPTIONS=--experimental-vm-modules ../../node_modules/.bin/jest",
     "test:watch": "pnpm run build:esm+types --watch & pnpm run test --watchAll",
-    "build:esm": "tsup --format esm && mv ./dist/esm/index.d.mts ./dist/esm/index.d.ts && mv ./dist/esm/gateway/index.d.mts ./dist/esm/gateway/index.d.ts",
-    "build:cjs": "tsup --format cjs",
+    "build:esm": "tsup --format esm",
+    "build:cjs": "tsup --format cjs && mv ./dist/cjs/index.d.cts ./dist/cjs/index.d.ts && mv ./dist/cjs/gateway/index.d.cts ./dist/cjs/gateway/index.d.ts",
     "build": "pnpm run build:esm && pnpm run build:cjs"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/knit/tsup.config.ts
+++ b/packages/knit/tsup.config.ts
@@ -57,7 +57,7 @@ export default defineConfig((options) => {
       return { ...esmOptions, ...options };
     default:
       throw new Error(
-        `Unexpected build format ${options.format} must be either cjs or esm`
+        `Unexpected build format ${options.format} must be either cjs or esm`,
       );
   }
 });

--- a/packages/knit/tsup.config.ts
+++ b/packages/knit/tsup.config.ts
@@ -3,45 +3,11 @@ import { writeFileSync } from "fs";
 
 const cjsPackageJson = {
   type: "commonjs",
-  main: "./index.js",
-  types: "./index.d.ts",
-  exports: {
-    ".": {
-      types: "./index.d.ts",
-      require: "./index.js",
-    },
-    "./gateway": {
-      types: "./gateway/index.d.ts",
-      require: "./gateway/index.js",
-    },
-  },
-  typesVersions: {
-    "*": {
-      gateway: ["./gateway/index.d.ts"],
-    },
-  },
 };
 
 const esmPackageJson = {
-  sideEffects: false,
   type: "module",
-  types: "./index.d.ts",
-  module: "./index.js",
-  exports: {
-    ".": {
-      types: "./index.d.ts",
-      import: "./index.js",
-    },
-    "./gateway": {
-      types: "./gateway/index.d.ts",
-      import: "./gateway/index.js",
-    },
-  },
-  typesVersions: {
-    "*": {
-      gateway: ["./gateway/index.d.ts"],
-    },
-  },
+  sideEffects: false,
 };
 
 const sharedOptions = {
@@ -50,12 +16,17 @@ const sharedOptions = {
   clean: true,
   treeshake: true,
   entry: ["./src/index.ts", "./src/gateway/index.ts"],
+  outExtension() {
+    return {
+      js: ".js",
+      dts: ".d.ts",
+    };
+  },
 } satisfies Options;
 
 const cjsOptions = {
   ...sharedOptions,
   format: "cjs",
-  legacyOutput: true, // Outputs `.js` instead of `.cjs`.
   outDir: "./dist/cjs",
   onSuccess: async () =>
     writeFileSync("./dist/cjs/package.json", JSON.stringify(cjsPackageJson)),
@@ -86,7 +57,7 @@ export default defineConfig((options) => {
       return { ...esmOptions, ...options };
     default:
       throw new Error(
-        `Unexpected build format ${options.format} must be either cjs or esm`,
+        `Unexpected build format ${options.format} must be either cjs or esm`
       );
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.11.0
+        version: 0.11.0
       '@types/node':
         specifier: ^20.8.0
         version: 20.8.0
@@ -144,6 +147,39 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
+    dev: true
+
+  /@andrewbranch/untar.js@1.0.2:
+    resolution: {integrity: sha512-hL80MHK3b++pEp6K23+Nl5r5D1F19DRagp2ruCBIv4McyCiLKq67vUNvEQY1aGCAKNZ8GxV23n5MhOm7RwO8Pg==}
+    dev: true
+
+  /@arethetypeswrong/cli@0.11.0:
+    resolution: {integrity: sha512-0GxlV58x8DaiWRUx0JWc3glr8iGsjK+KATuubH8qRqjw4aIGB8BBQ8Bv2Bvs9DfGuojBgbVWhOTe8+3BepYZ6Q==}
+    hasBin: true
+    dependencies:
+      '@arethetypeswrong/core': 0.10.2
+      chalk: 4.1.2
+      cli-table3: 0.6.3
+      commander: 10.0.1
+      marked: 5.1.2
+      marked-terminal: 5.2.0(marked@5.1.2)
+      node-fetch: 2.7.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /@arethetypeswrong/core@0.10.2:
+    resolution: {integrity: sha512-jL1MPpZKuMkm0EbZn1OLgdTO5hci7g79EUSELEnATdFyTgbPUxJwTXi1Kdont/BG05BZCcxZnOQgYO/whVmwdA==}
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.2
+      fetch-ponyfill: 7.1.0
+      fflate: 0.7.4
+      semver: 7.5.4
+      typescript: 5.2.2
+      validate-npm-package-name: 5.0.0
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /@babel/code-frame@7.18.6:
@@ -592,6 +628,13 @@ packages:
       typescript: 4.5.2
     transitivePeerDependencies:
       - supports-color
+
+  /@colors/colors@1.5.0:
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@connectrpc/connect-web@1.0.0(@bufbuild/protobuf@1.3.1)(@connectrpc/connect@1.0.0):
     resolution: {integrity: sha512-QMoq/KoZG2ZUAJptXqQtFVoZY9avX+11JDFrb+2P7rVOzHifupBPNTp4LJjTPciuUhpNwMCNnNXdddAh/+N2aw==}
@@ -1660,6 +1703,13 @@ packages:
       type-fest: 0.21.3
     dev: true
 
+  /ansi-escapes@6.2.0:
+    resolution: {integrity: sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      type-fest: 3.13.1
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1680,6 +1730,10 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /ansicolors@0.3.2:
+    resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
     dev: true
 
   /any-promise@1.3.0:
@@ -1828,6 +1882,12 @@ packages:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
 
+  /builtins@5.0.1:
+    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
+    dependencies:
+      semver: 7.5.4
+    dev: true
+
   /bundle-require@4.0.1(esbuild@0.18.20):
     resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1861,6 +1921,14 @@ packages:
     resolution: {integrity: sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==}
     dev: true
 
+  /cardinal@2.1.1:
+    resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
+    hasBin: true
+    dependencies:
+      ansicolors: 0.3.2
+      redeyed: 2.1.1
+    dev: true
+
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1876,6 +1944,11 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -1904,6 +1977,15 @@ packages:
 
   /cjs-module-lexer@1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+    dev: true
+
+  /cli-table3@0.6.3:
+    resolution: {integrity: sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==}
+    engines: {node: 10.* || >= 12.*}
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
     dev: true
 
   /cliui@8.0.1:
@@ -1942,6 +2024,11 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2339,6 +2426,18 @@ packages:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
       bser: 2.1.1
+    dev: true
+
+  /fetch-ponyfill@7.1.0:
+    resolution: {integrity: sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==}
+    dependencies:
+      node-fetch: 2.6.13
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
     dev: true
 
   /file-entry-cache@6.0.1:
@@ -3188,7 +3287,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3217,6 +3315,27 @@ packages:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
     dependencies:
       tmpl: 1.0.5
+    dev: true
+
+  /marked-terminal@5.2.0(marked@5.1.2):
+    resolution: {integrity: sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==}
+    engines: {node: '>=14.13.1 || >=16.0.0'}
+    peerDependencies:
+      marked: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+    dependencies:
+      ansi-escapes: 6.2.0
+      cardinal: 2.1.1
+      chalk: 5.3.0
+      cli-table3: 0.6.3
+      marked: 5.1.2
+      node-emoji: 1.11.0
+      supports-hyperlinks: 2.3.0
+    dev: true
+
+  /marked@5.1.2:
+    resolution: {integrity: sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==}
+    engines: {node: '>= 16'}
+    hasBin: true
     dev: true
 
   /merge-stream@2.0.0:
@@ -3261,6 +3380,36 @@ packages:
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  /node-emoji@1.11.0:
+    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+    dependencies:
+      lodash: 4.17.21
+    dev: true
+
+  /node-fetch@2.6.13:
+    resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -3466,6 +3615,12 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /redeyed@2.1.1:
+    resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
+    dependencies:
+      esprima: 4.0.1
+    dev: true
+
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3660,6 +3815,14 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /supports-hyperlinks@2.3.0:
+    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -3705,6 +3868,10 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
 
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
@@ -3882,6 +4049,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
+    dev: true
+
   /typescript@4.5.2:
     resolution: {integrity: sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==}
     engines: {node: '>=4.2.0'}
@@ -3918,14 +4090,32 @@ packages:
       convert-source-map: 1.9.0
     dev: true
 
+  /validate-npm-package-name@5.0.0:
+    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      builtins: 5.0.1
+    dev: true
+
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
       makeerror: 1.0.12
     dev: true
 
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
   /webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    dev: true
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: true
 
   /whatwg-url@7.1.0:

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,11 @@
       "inputs": ["src/**"],
       "outputs": ["dist/**/*"]
     },
+    "attw": {
+      "dependsOn": ["build"],
+      "inputs": ["dist/", "package.json"],
+      "outputs": []
+    },
     "test": {
       "dependsOn": ["build"],
       "outputs": []


### PR DESCRIPTION
Fix exports according to `attw`. Also add `attw` to CI. The fix is identical to https://github.com/connectrpc/connect-es/pull/838. The only difference is the use of `type` in `package.json`. This is required for `jest` to load modules.