### PR TITLE
Export `KnitService` from gateway

### DIFF
--- a/packages/knit/src/gateway/index.ts
+++ b/packages/knit/src/gateway/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 export { createKnitService } from "./service.js";
+export { KnitService } from "@buf/bufbuild_knit.connectrpc_es/buf/knit/gateway/v1alpha1/knit_connect.js";
 
 export type { CreateKnitServiceOptions } from "./service.js";
 export type { Gateway } from "./gateway.js";


### PR DESCRIPTION
Export `KnitService` from gateway. This is needed to use `createKnitService`