### PR TITLE
Add a register function for `KnitService`

### DIFF
--- a/packages/knit/src/gateway/index.ts
+++ b/packages/knit/src/gateway/index.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { createKnitService } from "./service.js";
-export { KnitService } from "@buf/bufbuild_knit.connectrpc_es/buf/knit/gateway/v1alpha1/knit_connect.js";
+export { createKnitService, registerKnitService } from "./service.js";
 
 export type { CreateKnitServiceOptions } from "./service.js";
 export type { Gateway } from "./gateway.js";

--- a/packages/knit/src/gateway/service.ts
+++ b/packages/knit/src/gateway/service.ts
@@ -15,6 +15,7 @@
 import {
   Code,
   ConnectError,
+  type ConnectRouter,
   type HandlerContext,
   type ServiceImpl,
   type Transport,
@@ -57,6 +58,13 @@ import { min } from "./util.js";
 const doOperation = `${KnitService.typeName}.${KnitService.methods.do.name}`;
 const fetchOperation = `${KnitService.typeName}.${KnitService.methods.fetch.name}`;
 const listenOperation = `${KnitService.typeName}.${KnitService.methods.listen.name}`;
+
+export function registerKnitService(
+  router: ConnectRouter,
+  options: CreateKnitServiceOptions,
+) {
+  router.service(KnitService, createKnitService(options));
+}
 
 /**
  * Options accepted by {@link createKnitService}.


### PR DESCRIPTION
Add a register function for `KnitService`. This avoids the `KnitService` export and should remove the dep on generated sdk.