### PR TITLE
Remove `makeOneof` to simplify creating `Oneof` values

### DIFF
--- a/packages/knit/src/gateway/headers.test.ts
+++ b/packages/knit/src/gateway/headers.test.ts
@@ -42,7 +42,7 @@ describe("well known headers", () => {
 });
 
 describe("well known prefix", () => {
-  const prefixes = [":", "Accept-", "Connect-", "Content-", "If-", "Grpc-"];
+  const prefixes = ["Accept-", "Connect-", "Content-", "If-", "Grpc-"];
   for (const prefix of prefixes) {
     test(prefix, () => {
       const header = prefix + "-FOO";

--- a/packages/knit/src/index.ts
+++ b/packages/knit/src/index.ts
@@ -22,7 +22,6 @@
  * @packageDocumentation
  */
 
-export { makeOneof } from "./oneof.js";
 export { alias } from "./alias.js";
 export { createClient } from "./client.js";
 export { makeScopedClient } from "./scope.js";

--- a/packages/knit/src/json.test.ts
+++ b/packages/knit/src/json.test.ts
@@ -26,7 +26,6 @@ import {
   Schema_Field_Type_ScalarType,
 } from "@buf/bufbuild_knit.bufbuild_es/buf/knit/gateway/v1alpha1/knit_pb.js";
 import { decodeMessage, format } from "./json.js";
-import { makeOneof } from "./oneof.js";
 import { Timestamp } from "./wkt/timestamp.js";
 import type { Any } from "./wkt/any.js";
 import type { Struct } from "./wkt/struct.js";
@@ -94,7 +93,7 @@ describe("format", () => {
     },
     {
       name: "oneof",
-      i: { oneof: makeOneof({ a: "some" }) },
+      i: { oneof: { "@case": "a", value: "some" } },
       o: { a: "some" },
     },
     // WKT wrappers are treated as primitives
@@ -480,7 +479,7 @@ describe("decode", () => {
           "",
         );
         expect(result).toStrictEqual({
-          key: { oneofKey: makeOneof({ key: testCase.o }) },
+          key: { oneofKey: { "@case": "key", value: testCase.o } },
         });
       });
     }
@@ -785,7 +784,7 @@ describe("decode", () => {
           "",
         );
         expect(result).toStrictEqual({
-          key: { oneofKey: makeOneof({ key: testCase.o }) },
+          key: { oneofKey: { "@case": "key", value: testCase.o } },
         });
       });
     }
@@ -932,7 +931,7 @@ describe("decode", () => {
       "",
     ) as any;
 
-    expect(result.key1[0].key2.item.case).toBe("opt1");
+    expect(result.key1[0].key2.item["@case"]).toBe("opt1");
     expect(result.key1[0].key2.item.value).toStrictEqual({ value: 1 });
   });
 
@@ -1045,7 +1044,7 @@ describe("decode", () => {
       "",
     ) as any;
 
-    expect(result.key1["someId"].key2.item.case).toBe("opt1");
+    expect(result.key1["someId"].key2.item["@case"]).toBe("opt1");
     expect(result.key1["someId"].key2.item.value).toStrictEqual({
       value: 1,
     });

--- a/packages/knit/src/json.ts
+++ b/packages/knit/src/json.ts
@@ -27,8 +27,7 @@ import {
   type Schema_Field_Type_RepeatedType,
   Error as PBError,
 } from "@buf/bufbuild_knit.bufbuild_es/buf/knit/gateway/v1alpha1/knit_pb.js";
-import { getOneof, makeOneof } from "./oneof.js";
-import type { AnyRecord } from "./utils/types.js";
+import { getOneof } from "./oneof.js";
 import { Duration } from "./wkt/duration.js";
 import { Timestamp } from "./wkt/timestamp.js";
 import { FieldMask } from "./wkt/field_mask.js";
@@ -97,7 +96,7 @@ export function format(data: unknown): JsonValue {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             const oneof = getOneof(value);
             if (oneof !== undefined) {
-              key = oneof.case;
+              key = oneof["@case"];
               value = oneof.value;
             }
           }
@@ -155,9 +154,10 @@ export function decodeMessage(
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (oneOfField !== undefined) {
-      result[oneOfField] = makeOneof({
-        [field.name]: value,
-      } as AnyRecord);
+      result[oneOfField] = {
+        "@case": field.name,
+        value,
+      };
       continue;
     }
     result[field.name] = value;

--- a/packages/knit/src/oneof.test.ts
+++ b/packages/knit/src/oneof.test.ts
@@ -12,27 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, test, expect } from "@jest/globals";
-import { makeOneof } from "./oneof.js";
+import { describe, test } from "@jest/globals";
 import type { Oneof } from "./oneof.js";
-
 type Cases = { a: string; b: number };
 
-describe("makeOneof", () => {
-  test("accepts one", () => {
-    const p = makeOneof<Cases>({ a: "knit" });
-    expect(p).toHaveProperty("case", "a");
-    expect(p).toHaveProperty("value", "knit");
-    const q = makeOneof<Cases>({ b: 1 });
-    expect(q).toHaveProperty("case", "b");
-    expect(q).toHaveProperty("value", 1);
-  });
-  test("throws if not one", () => {
-    expect(() => makeOneof<Cases>({} as any)).toThrowError();
-  });
-});
-
 describe("Oneof", () => {
+  const f = (_: Oneof<Cases>) => {};
+  test("works for correct cases", () => {
+    f({ "@case": "a", value: "str" });
+    f({ "@case": "b", value: 123 });
+  });
   test("fails on empty object", () => {
     //@ts-expect-error
     const _ = {} satisfies Oneof<Cases>;


### PR DESCRIPTION
Remove `makeOneof` to simplify creating `Oneof` values. This is breaking change, `Oneof` has also changed to use simple fields instead of getters. `case` has been renamed to `@case` in `Oneof`.